### PR TITLE
Add processor routing mixin

### DIFF
--- a/examples/dynamic_routing_example.py
+++ b/examples/dynamic_routing_example.py
@@ -1,0 +1,25 @@
+"""Example demonstrating processor-level routing between OpenAI and local vision models."""
+import os
+from llm_factory.processors.standard_processor import StandardPromptProcessor
+from llm_factory.utils import image_to_data_uri
+
+
+def main() -> None:
+    processor = StandardPromptProcessor()
+
+    # Text-based call -> always OpenAI
+    text_result = processor.get_completion("Explain the moon landing in one sentence.")
+    print("Text Response:\n", text_result)
+
+    # Vision-based call -> routed to LM Studio or Ollama depending on ENV
+    sample_image = os.path.join(os.path.dirname(__file__), "sample.jpg")
+    if os.path.isfile(sample_image):
+        data_uri = image_to_data_uri(sample_image)
+        image_result = processor.get_response_image("What is in this picture?", data_uri)
+        print("Vision Response:\n", image_result)
+    else:
+        print("Sample image not found; skipping vision request")
+
+
+if __name__ == "__main__":
+    main()

--- a/llm_factory/__init__.py
+++ b/llm_factory/__init__.py
@@ -55,6 +55,10 @@ from .parsers.docx.parser import DocxParser
 from .parsers.pptx.parser import PPTProcessor
 
 # Exposing specific processor implementations and base class
+from .processors.standard_processor import StandardPromptProcessor
+from .processors.cot_processor import ChainOfThoughtProcessor
+from .processors.routing_mixin import RoutingMixin
+
 # Import utility functions
 from llm_factory.utils import (
     encode_image_to_base64,
@@ -79,6 +83,7 @@ __all__ = [
     "BasePromptProcessor",  # Base Class for processors, for users to extend
     "StandardPromptProcessor",
     "ChainOfThoughtProcessor",
+    "RoutingMixin",
     "ParserFactory",
     "BaseParser",  # Base Class for parsers, for users to extend
     "PDFParser",

--- a/llm_factory/env_loader.py
+++ b/llm_factory/env_loader.py
@@ -68,10 +68,20 @@ def load_environment(env_path: Optional[str] = None) -> Dict[str, Any]:
         "api_request_timeout": int(os.getenv("API_REQUEST_TIMEOUT", "60")),
         "max_retries": int(os.getenv("MAX_RETRIES", "3")),
         "retry_delay": int(os.getenv("RETRY_DELAY", "1")),
-        
+
         # Default Pipeline Configuration
         "default_pipeline_type": os.getenv("DEFAULT_PIPELINE_TYPE", "standard"),
         "default_client_type": os.getenv("DEFAULT_CLIENT_TYPE", "openrouter"),
+
+        # Vision model configuration
+        "vision": {
+            "enabled": os.getenv("VISION_MODEL_ENABLED", "false").lower() == "true",
+            "client_type": os.getenv("VISION_CLIENT_TYPE", "lmstudio"),
+            "model_name": os.getenv("VISION_MODEL_NAME"),
+            "lmstudio_url": os.getenv("LM_STUDIO"),
+            "ollama_url": os.getenv("OLLAMA_HOST_URL"),
+            "ollama_model": os.getenv("OLLAMA_MODEL_NAME"),
+        },
     }
     
     # Check for missing required environment variables

--- a/llm_factory/processors/cot_processor.py
+++ b/llm_factory/processors/cot_processor.py
@@ -5,6 +5,7 @@ import hashlib
 from typing import Any, Dict, List, Optional, Union
 
 from .base_processor import BasePromptProcessor
+from .routing_mixin import RoutingMixin
 try:
     from ..utils.dry_run_logger import create_dry_run_logger
 except ImportError:
@@ -20,7 +21,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-class ChainOfThoughtProcessor(BasePromptProcessor):
+class ChainOfThoughtProcessor(RoutingMixin, BasePromptProcessor):
     """
     Enhanced Processor for Chain of Thought (CoT) pipelines with fine-tuning capabilities.
 
@@ -30,7 +31,8 @@ class ChainOfThoughtProcessor(BasePromptProcessor):
     """
 
     def __init__(self):
-        """Initialize the Chain of Thought processor with fine-tuning capabilities"""
+        """Initialize the Chain of Thought processor with routing and fine-tuning."""
+        super().__init__()
         self.message_history = []  # For CoT pipeline
         self.raw_history = []      # For CoT pipeline
 

--- a/llm_factory/processors/routing_mixin.py
+++ b/llm_factory/processors/routing_mixin.py
@@ -1,0 +1,104 @@
+import os
+import time
+import logging
+from typing import Any, Dict
+from dotenv import load_dotenv
+
+from llm_factory.clients import OpenAILLMClient, LMStudioClient, OllamaLLMClient
+
+logger = logging.getLogger(__name__)
+
+class RoutingMixin:
+    """Mixin providing environment-aware client routing for processors."""
+
+    def __init__(self, *args, **kwargs):
+        load_dotenv()
+        self.env = self._load_env()
+        self._init_clients()
+        super().__init__(*args, **kwargs)
+
+    def _load_env(self) -> Dict[str, Any]:
+        return {
+            "VISION_MODEL_ENABLED": os.getenv("VISION_MODEL_ENABLED", "false").lower() == "true",
+            "VISION_CLIENT_TYPE": os.getenv("VISION_CLIENT_TYPE", "lmstudio").lower(),
+            "VISION_MODEL_NAME": os.getenv("VISION_MODEL_NAME", "qwen-7b"),
+            "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY"),
+            "OPENAI_MODEL_NAME": os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini"),
+            "LM_STUDIO": os.getenv("LM_STUDIO", "http://localhost:1234"),
+            "OLLAMA_HOST_URL": os.getenv("OLLAMA_HOST_URL", "http://localhost:11434"),
+            "OLLAMA_MODEL_NAME": os.getenv("OLLAMA_MODEL_NAME", "llama3.2"),
+            "DEFAULT_TEMPERATURE": float(os.getenv("DEFAULT_TEMPERATURE", "0")),
+            "DEFAULT_MAX_TOKENS": int(os.getenv("DEFAULT_MAX_TOKENS", "8000")),
+            "API_REQUEST_TIMEOUT": int(os.getenv("API_REQUEST_TIMEOUT", "60")),
+            "MAX_RETRIES": int(os.getenv("MAX_RETRIES", "3")),
+            "RETRY_DELAY": int(os.getenv("RETRY_DELAY", "1")),
+        }
+
+    def _init_clients(self) -> None:
+        self.openai_client = OpenAILLMClient(
+            api_key=self.env["OPENAI_API_KEY"],
+            model_name=self.env["OPENAI_MODEL_NAME"],
+            default_temperature=self.env["DEFAULT_TEMPERATURE"],
+            default_max_tokens=self.env["DEFAULT_MAX_TOKENS"],
+        )
+
+        self.lmstudio_client = LMStudioClient(
+            base_url=self.env["LM_STUDIO"],
+            model_name=self.env["VISION_MODEL_NAME"],
+            default_temperature=self.env["DEFAULT_TEMPERATURE"],
+            default_max_tokens=self.env["DEFAULT_MAX_TOKENS"],
+        )
+
+        self.ollama_client = OllamaLLMClient(
+            host_url=self.env["OLLAMA_HOST_URL"],
+            model_name=self.env["VISION_MODEL_NAME"],
+            default_temperature=self.env["DEFAULT_TEMPERATURE"],
+            default_max_tokens=self.env["DEFAULT_MAX_TOKENS"],
+        )
+
+    # ----- helper methods -----
+    def get_completion(self, prompt: str, **kwargs) -> str:
+        """Always route text completions to OpenAI."""
+        messages = [{"role": "user", "content": prompt}]
+        params = {
+            "messages": messages,
+            "temperature": kwargs.get("temperature", self.env["DEFAULT_TEMPERATURE"]),
+            "max_tokens": kwargs.get("max_tokens", self.env["DEFAULT_MAX_TOKENS"]),
+        }
+        return self.openai_client.generate_completion(**params)
+
+    def _vision_client(self):
+        if self.env["VISION_CLIENT_TYPE"] == "lmstudio":
+            return self.lmstudio_client
+        if self.env["VISION_CLIENT_TYPE"] == "ollama":
+            return self.ollama_client
+        raise ValueError(f"Unsupported vision client type: {self.env['VISION_CLIENT_TYPE']}")
+
+    def get_response_image(self, prompt: str, image_data: str, **kwargs) -> str:
+        """Route image or PDF prompts to the configured vision backend."""
+        client = self.openai_client
+        if self.env["VISION_MODEL_ENABLED"]:
+            client = self._vision_client()
+
+        attempts = 0
+        while attempts < self.env["MAX_RETRIES"]:
+            try:
+                return client.get_openai_response_image(
+                    image_data=image_data,
+                    prompt=prompt,
+                    model=self.env["VISION_MODEL_NAME"],
+                )
+            except Exception as e:
+                attempts += 1
+                logger.warning(f"Vision request failed (attempt {attempts}): {e}")
+                time.sleep(self.env["RETRY_DELAY"])
+
+        logger.error("Vision client failed after retries")
+        # Fallback to OpenAI if not already using it
+        if client is not self.openai_client:
+            return self.openai_client.get_openai_response_image(
+                image_data=image_data,
+                prompt=prompt,
+                model=self.env["OPENAI_MODEL_NAME"],
+            )
+        raise RuntimeError("Image processing failed after retries")

--- a/llm_factory/processors/standard_processor.py
+++ b/llm_factory/processors/standard_processor.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional, Union, Tuple
 
 from .base_processor import BasePromptProcessor
+from .routing_mixin import RoutingMixin
 try:
     from ..utils.dry_run_logger import create_dry_run_logger
 except ImportError:
@@ -19,14 +20,15 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-class StandardPromptProcessor(BasePromptProcessor):
+class StandardPromptProcessor(RoutingMixin, BasePromptProcessor):
     """
     Processor for standard prompts with JSON extraction and optional tonality matching.
     Handles traditional extraction + tonality workflow.
     """
     
     def __init__(self):
-        """Initialize the Standard processor with dry-run logging capabilities"""
+        """Initialize the Standard processor with routing and dry-run support"""
+        super().__init__()
         self.dry_run_logger = None
 
     def process(self, client, prompt_config: Dict[str, Any], **kwargs) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- parse vision settings in `env_loader`
- add `RoutingMixin` for automatic client routing
- integrate mixin into Standard and CoT processors
- expose mixin at package level
- add example showing runtime switch

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError and assertion issues)*

------
https://chatgpt.com/codex/tasks/task_e_68702cc7121c83288870e21113fa6132